### PR TITLE
Add diet type filtering

### DIFF
--- a/src/HomeScreen/HomeScreen.jsx
+++ b/src/HomeScreen/HomeScreen.jsx
@@ -14,6 +14,7 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { Layout } from "../components/Layout";
 import { violatesReligion } from "../utils/religionRules";
+import { violatesDiet } from "../utils/dietRules";
 
 export const HomeScreen = ({ onNavigate, className, ...props }) => {
   const { t, i18n } = useTranslation();
@@ -36,6 +37,7 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
   const [loginTab, setLoginTab] = useState("login");
   const [allergies, setAllergies] = useState([]);
   const [religions, setReligions] = useState([]);
+  const [dietType, setDietType] = useState("");
 
   // 알레르기 코드 → 이름 매핑
   const allergyMap = {
@@ -93,6 +95,7 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
           setSchoolCode(d.schoolCode || "");
           setAllergies(d.allergies || []);
           setReligions(d.religion || []);
+          setDietType(d.dietType || "");
         }
       } else {
         setSchoolName(t("select_school"));
@@ -100,6 +103,7 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
         setSchoolCode("");
         setAllergies([]);
         setReligions([]);
+        setDietType("");
       }
     }
     fetchUserSettings();
@@ -300,12 +304,17 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
               <div>{t("no_meal_data")}</div>
             ) : (
               meals.map((menu, idx) => {
-                const hasAllergy = menu.ingredients.some(i => allergies.includes(i));
-                const violates = violatesReligion(menu.name, religions);
+                const hasAllergy = menu.ingredients.some((i) => allergies.includes(i));
+                const religionBan = violatesReligion(menu.name, religions);
+                const dietBan = violatesDiet(menu.name, menu.ingredients, dietType);
                 let className = "simple-meal-item";
                 let icon = "✅";
                 let label = t("can_eat");
-                if (violates) {
+                if (dietBan) {
+                  className += " exclude";
+                  icon = "❌";
+                  label = t("diet_violation");
+                } else if (religionBan) {
                   className += " exclude";
                   icon = "❌";
                   label = t("religion_violation");

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,6 +23,7 @@
   "meal": "Meal",
   "allergy_warning": "Allergy Warning",
   "religion_violation": "Not allowed by religion",
+  "diet_violation": "Not allowed by diet",
   "can_eat": "Can eat",
   "feedback": "Leave feedback",
   "date": "Date",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -49,6 +49,7 @@
   "meal": "급식",
   "allergy_warning": "알레르기 주의",
   "religion_violation": "종교상 금지",
+  "diet_violation": "식습관상 금지",
   "can_eat": "먹을 수 있어요",
   "feedback": "피드백 남기기",
   "date": "날짜",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -22,6 +22,7 @@
   "meal": "餐食",
   "allergy_warning": "过敏警告",
   "religion_violation": "宗教禁止",
+  "diet_violation": "饮食限制",
   "can_eat": "可以吃",
   "feedback": "留下反馈",
   "date": "日期",

--- a/src/utils/dietRules.js
+++ b/src/utils/dietRules.js
@@ -1,0 +1,29 @@
+export const dietRestrictions = {
+  "비건": [
+    // exclude all animal-derived foods
+    "돼지", "소", "쇠고기", "소고기", "닭", "치킨", "오리",
+    "고등어", "갈치", "참치", "연어", "오징어", "새우", "게", "조개",
+    "계란", "달걀", "난", "우유", "치즈", "버터", "요거트", "꿀"
+  ],
+  "락토오보": [
+    // allow eggs and dairy, disallow meat and fish
+    "돼지", "소", "쇠고기", "소고기", "닭", "치킨", "오리",
+    "고등어", "갈치", "참치", "연어", "오징어", "새우", "게", "조개"
+  ],
+  "페스코": [
+    // allow fish, disallow other meats
+    "돼지", "소", "쇠고기", "소고기", "닭", "치킨", "오리"
+  ],
+  "일반식": [],
+  "기타": []
+};
+
+export function violatesDiet(name = "", ingredients = [], type = "") {
+  const rules = dietRestrictions[type] || [];
+  if (rules.length === 0) return false;
+  for (const kw of rules) {
+    if (name.includes(kw)) return true;
+    if (ingredients.some((ing) => ing.includes(kw))) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- implement diet rules and check them in meal screens
- flag disallowed meals for each diet type
- add translations for diet violation message

## Testing
- `node node_modules/vite/bin/vite.js build`

------
https://chatgpt.com/codex/tasks/task_e_685793a6958c83309f60908e4adaad51