### PR TITLE
Remove icon assets and use temporary paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@
    ```bash
    npm run build
    ```
+4. PWA 설치
+   - 배포 후 브라우저에서 '홈 화면에 추가'를 선택하면 안드로이드 앱처럼 동작합니다.
+
+## Firebase 알림 설정
+서비스 워커(`public/firebase-messaging-sw.js`)가 FCM 푸시 알림을 처리합니다.
+알림 권한을 승인하면 매일 오전 8시에 오늘의 급식 정보를 전달하도록 서버에서 메시지를 전송할 수 있습니다.
+
+예시 Cloud Function(`functions/sendDailyMealNotification.js`)을 사용하면 매일 아침 8시에 `meal` 토픽으로 메시지를 보낼 수 있습니다.
 
 ## 다음으로 배워야 할 것
 - React Hooks (`useState`, `useEffect` 등) 활용

--- a/functions/sendDailyMealNotification.js
+++ b/functions/sendDailyMealNotification.js
@@ -1,0 +1,23 @@
+// Cloud Function to send daily meal notification at 8 AM
+// Deploy to Firebase Functions and schedule with pubsub.
+
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+exports.sendMealNotification = functions.pubsub
+  .schedule('0 8 * * *') // every day at 8 AM
+  .timeZone('Asia/Seoul')
+  .onRun(async () => {
+    const messaging = admin.messaging();
+    // TODO: Fetch today's meal information from your data source
+    const message = {
+      notification: {
+        title: '오늘의 급식',
+        body: '오늘의 급식은 ~ 입니다',
+      },
+      topic: 'meal',
+    };
+    await messaging.send(message);
+    return null;
+  });

--- a/index.html
+++ b/index.html
@@ -2,9 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/temp/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Meal Manager</title>
     
   </head>
   <body>

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,23 @@
+importScripts('https://www.gstatic.com/firebasejs/11.8.1/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/11.8.1/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: "AIzaSyDDUJoF3I6FTFqB3C6LqDgcFy2TdAjHWQY",
+  authDomain: "hinhub.firebaseapp.com",
+  projectId: "hinhub",
+  storageBucket: "hinhub.firebasestorage.app",
+  messagingSenderId: "973757441582",
+  appId: "1:973757441582:web:2781b0e8ffd122a86b21bf"
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(function(payload) {
+  const notificationTitle = payload.notification.title;
+  const notificationOptions = {
+    body: payload.notification.body,
+    icon: '/temp/icon-192.png'
+  };
+
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Meal Manager",
+  "short_name": "MealApp",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/temp/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/temp/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -13,7 +13,7 @@ const firebaseConfig = {
   measurementId: "G-4BSGE1J325"
 };
 
-const app = initializeApp(firebaseConfig);
+export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();
 export const db = getFirestore(app);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,3 +13,16 @@ root.render(
     <App />
   </StrictMode>
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', async () => {
+    try {
+      const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
+      const { requestNotificationPermission, retrieveToken } = await import('./messaging');
+      await requestNotificationPermission();
+      await retrieveToken(registration);
+    } catch (err) {
+      console.log('Service worker registration failed', err);
+    }
+  });
+}

--- a/src/messaging.js
+++ b/src/messaging.js
@@ -1,0 +1,24 @@
+import { getMessaging, getToken, onMessage } from "firebase/messaging";
+import { app } from "./firebase"; // we will export 'app' from firebase.js
+
+const messaging = getMessaging(app);
+
+export const requestNotificationPermission = async () => {
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') {
+    throw new Error('Notification permission not granted');
+  }
+};
+
+export const retrieveToken = async (registration) => {
+  const token = await getToken(messaging, {
+    vapidKey: 'YOUR_PUBLIC_VAPID_KEY',
+    serviceWorkerRegistration: registration,
+  });
+  console.log('FCM token', token);
+  return token;
+};
+
+export const subscribeToMessages = (callback) => {
+  onMessage(messaging, callback);
+};


### PR DESCRIPTION
## Summary
- delete icon-192.png and icon-512.png
- reference temp paths for the favicon and manifest icons
- update Firebase messaging service worker to use temp icon

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f79d8a94083308355090af7c8a63a