### PR TITLE
Fix login UI overlap

### DIFF
--- a/src/HomeScreen/HomeScreen.css
+++ b/src/HomeScreen/HomeScreen.css
@@ -92,6 +92,27 @@
   flex-shrink: 0;
   position: relative;
 }
+.home-screen .user-info {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  align-items: center;
+  justify-content: flex-end;
+  font-size: 13px;
+  max-width: 45%;
+}
+.home-screen .user-email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.home-screen .header-login,
+.home-screen .header-logout {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+}
 .home-screen .calendar {
   flex-shrink: 0;
   width: 20px;

--- a/src/HomeScreen/HomeScreen.jsx
+++ b/src/HomeScreen/HomeScreen.jsx
@@ -189,21 +189,6 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
 
   return (
     <div className={"home-screen " + className}>
-      {/* 로그인 버튼/유저 표시 */}
-      <div style={{ position: "absolute", right: 20, top: 10, zIndex: 10 }}>
-        {user ? (
-          <span style={{ fontSize: 13 }}>
-            {user.email}
-            <button onClick={handleLogout} style={{ marginLeft: 10, fontSize: 13 }}>
-              {t("logout")}
-            </button>
-          </span>
-        ) : (
-          <button onClick={() => setShowLogin(true)} style={{ fontSize: 13 }}>
-            {t("login")}/{t("register")}
-          </button>
-        )}
-      </div>
       {showLogin && (
         <div className="login-modal-bg">
           <div className="login-modal">
@@ -284,6 +269,20 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
               showPopperArrow={false}
               locale={i18n.language}
             />
+          </div>
+          <div className="user-info">
+            {user ? (
+              <>
+                <span className="user-email">{user.email}</span>
+                <button onClick={handleLogout} className="header-logout">
+                  {t("logout")}
+                </button>
+              </>
+            ) : (
+              <button onClick={() => setShowLogin(true)} className="header-login">
+                {t("login")}/{t("register")}
+              </button>
+            )}
           </div>
         </div>
         <div className="school-info">


### PR DESCRIPTION
## Summary
- refactor HomeScreen header to move login controls into `date-row`
- add styles for new `.user-info` area

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868c400e9448330b2a5f51bb3d558df