### PR TITLE
Add login notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 
 예시 Cloud Function(`functions/sendDailyMealNotification.js`)을 사용하면 매일 아침 8시에 `meal` 토픽으로 메시지를 보낼 수 있습니다.
 
+또한 로그인 성공 시 알림을 전송하려면 `functions/sendLoginNotification.js`를 Cloud Functions에 배포하고, 앱에서 로그인 완료 후 해당 함수를 호출하면 됩니다.
+
 ## 다음으로 배워야 할 것
 - React Hooks (`useState`, `useEffect` 등) 활용
 - Firebase 인증 흐름과 Firestore 쿼리

--- a/functions/sendLoginNotification.js
+++ b/functions/sendLoginNotification.js
@@ -1,0 +1,21 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+// Initialize app only if not already initialized
+try {admin.app();} catch {admin.initializeApp();}
+
+exports.sendLoginNotification = functions.https.onCall(async (data, context) => {
+  const token = data && data.token;
+  if (!token) {
+    throw new functions.https.HttpsError('invalid-argument', 'No token provided');
+  }
+  const message = {
+    notification: {
+      title: '로그인 성공',
+      body: '앱에 로그인 되었습니다',
+    },
+    token,
+  };
+  await admin.messaging().send(message);
+  return { success: true };
+});

--- a/src/HomeScreen/HomeScreen.jsx
+++ b/src/HomeScreen/HomeScreen.jsx
@@ -1,7 +1,7 @@
 import "./HomeScreen.css";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { auth, db, googleProvider } from "../firebase";
+import { auth, db, googleProvider, functions } from "../firebase";
 import {
   signInWithEmailAndPassword,
   signOut,
@@ -15,10 +15,12 @@ import "react-datepicker/dist/react-datepicker.css";
 import { Layout } from "../components/Layout";
 import { violatesReligion } from "../utils/religionRules";
 import { violatesDiet } from "../utils/dietRules";
-import { showLocalNotification } from "../messaging";
+import { showLocalNotification, getCurrentToken } from "../messaging";
+import { httpsCallable } from "firebase/functions";
 
 export const HomeScreen = ({ onNavigate, className, ...props }) => {
   const { t, i18n } = useTranslation();
+  const sendLoginNotification = httpsCallable(functions, 'sendLoginNotification');
 
   // 급식/학교 관련
   const [meals, setMeals] = useState([]);
@@ -157,6 +159,10 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
       await signInWithEmailAndPassword(auth, email, password);
       setShowLogin(false);
       showLocalNotification(t('login_success'), { icon: '/temp/icon-192.png' });
+      const token = getCurrentToken();
+      if (token) {
+        try { await sendLoginNotification({ token }); } catch (e) { console.log('sendLoginNotification failed', e); }
+      }
     } catch (err) {
       setLoginError(t("login_failed"));
     }
@@ -168,6 +174,10 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
       await createUserWithEmailAndPassword(auth, email, password);
       setShowLogin(false);
       showLocalNotification(t('login_success'), { icon: '/temp/icon-192.png' });
+      const token = getCurrentToken();
+      if (token) {
+        try { await sendLoginNotification({ token }); } catch (e) { console.log('sendLoginNotification failed', e); }
+      }
     } catch (err) {
       setLoginError(t("register_failed") + err.message);
     }
@@ -183,6 +193,10 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
       await signInWithPopup(auth, googleProvider);
       setShowLogin(false);
       showLocalNotification(t('login_success'), { icon: '/temp/icon-192.png' });
+      const token = getCurrentToken();
+      if (token) {
+        try { await sendLoginNotification({ token }); } catch (e) { console.log('sendLoginNotification failed', e); }
+      }
     } catch (err) {
       setLoginError(t("google_login") + ": " + err.message);
     }

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,7 +1,7 @@
-
 import { initializeApp } from "firebase/app";
-import { getAuth,GoogleAuthProvider } from "firebase/auth";
+import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
+import { getFunctions } from "firebase/functions";
 
 const firebaseConfig = {
   apiKey: "AIzaSyDDUJoF3I6FTFqB3C6LqDgcFy2TdAjHWQY",
@@ -17,3 +17,4 @@ export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();
 export const db = getFirestore(app);
+export const functions = getFunctions(app);

--- a/src/messaging.js
+++ b/src/messaging.js
@@ -4,6 +4,8 @@ import { app } from "./firebase"; // firebase.js에서 export한 'app'
 
 const messaging = getMessaging(app);
 
+let currentToken = null;
+
 // 알림 권한 요청
 export const requestNotificationPermission = async () => {
   const permission = await Notification.requestPermission();
@@ -14,18 +16,20 @@ export const requestNotificationPermission = async () => {
 
 // FCM 토큰 가져오기
 export const retrieveToken = async (registration) => {
-  const token = await getToken(messaging, {
+  currentToken = await getToken(messaging, {
     vapidKey: "973757441582", // 여기에 VAPID 키 입력
     serviceWorkerRegistration: registration,
   });
-  console.log("FCM token", token);
-  return token;
+  console.log("FCM token", currentToken);
+  return currentToken;
 };
 
 // 메시지 수신시 콜백 처리
 export const subscribeToMessages = (callback) => {
   onMessage(messaging, callback);
 };
+
+export const getCurrentToken = () => currentToken;
 
 // 로컬 푸시 알림 표시
 export const showLocalNotification = (title, options = {}) => {


### PR DESCRIPTION
## Summary
- add Cloud Function to send push notification after login
- expose Firebase functions and current FCM token on the client
- notify the server on successful login
- document how to enable login notifications

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871f6d713c08330adff2c9e7d94e49b