### PR TITLE
Fix layout ratios and remove feedback button

### DIFF
--- a/src/HomeScreen/HomeScreen.css
+++ b/src/HomeScreen/HomeScreen.css
@@ -9,9 +9,10 @@
   gap: 0px;
   align-items: flex-start;
   justify-content: flex-start;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   position: relative;
-  
+
 }
 .home-screen .status-bar {
   padding: 0px 16px 0px 16px;

--- a/src/HomeScreen/HomeScreen.jsx
+++ b/src/HomeScreen/HomeScreen.jsx
@@ -398,10 +398,6 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
           </div>
         </div>
       </div>
-      <div className="feedback-button">
-        <img className="message-square" src="message-square0.svg" />
-        <div className="div8">{t("feedback")}</div>
-      </div>
     </div>
   );
 };

--- a/src/SettingsScreen/SettingsScreen.css
+++ b/src/SettingsScreen/SettingsScreen.css
@@ -1,7 +1,8 @@
 .settings-screen {
   padding: 20px;
   background: #fff;
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
   font-family: 'Inter', sans-serif;
 }
 .header .div {
@@ -23,6 +24,7 @@
   display: flex;
   gap: 12px;
   margin-top: 10px;
+  flex-wrap: wrap;
 }
 .religion-option, .diet-option {
   padding: 8px 16px;


### PR DESCRIPTION
## Summary
- fix 100vh layout on HomeScreen
- remove unused feedback button
- wrap religion and diet buttons so they don't overflow
- ensure SettingsScreen takes full viewport height

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: Rollup couldn't resolve firebase/messaging)*

------
https://chatgpt.com/codex/tasks/task_e_687c7b1d70388330a09d3aaeb194465a