### PR TITLE
Refine home screen date handling and header actions

### DIFF
--- a/src/HomeScreen/HomeScreen.css
+++ b/src/HomeScreen/HomeScreen.css
@@ -1,4 +1,4 @@
-.home-screen,
+.home-screen, /* modified by AI agent */
 .home-screen * {
   box-sizing: border-box;
 }
@@ -74,21 +74,12 @@
   flex-shrink: 0;
   position: relative;
 }
-.home-screen .date-row {
+.home-screen .header-top {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-self: stretch;
-  flex-shrink: 0;
-  position: relative;
-}
-.home-screen .date-info {
-  display: flex;
-  flex-direction: row;
-  gap: 8px;
-  align-items: center;
-  justify-content: flex-start;
   flex-shrink: 0;
   position: relative;
 }
@@ -108,26 +99,18 @@
 }
 .home-screen .header-login,
 .home-screen .header-logout {
-  background: none;
+  background: #007aff;
   border: none;
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
   cursor: pointer;
   font-size: 13px;
 }
-.home-screen .calendar {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  position: relative;
-  overflow: visible;
-}
-.home-screen ._2025-5-28 {
-  color: #000000;
-  text-align: left;
-  font-family: "Inter-SemiBold", sans-serif;
-  font-size: 18px;
-  line-height: 21.6px;
-  font-weight: 600;
-  position: relative;
+
+.home-screen .header-login:hover,
+.home-screen .header-logout:hover {
+  background: #005bb5;
 }
 .home-screen .settings {
   flex-shrink: 0;
@@ -154,7 +137,7 @@
   overflow: visible;
   vertical-align: middle;
 }
-.home-screen .div {
+.home-screen .school-name {
   color: #6c757d;
   text-align: left;
   font-family: "Inter-Medium", sans-serif;
@@ -209,6 +192,27 @@
   line-height: 24px;
   font-weight: 700;
   position: relative;
+}
+
+.home-screen .meal-date-row {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+}
+
+.home-screen .date-select-btn {
+  background: #fff;
+  border: 1px solid #007aff;
+  color: #007aff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.home-screen .date-select-btn:hover {
+  background: #e6f0ff;
 }
 .home-screen .meal-items {
   display: flex;

--- a/src/HomeScreen/HomeScreen.jsx
+++ b/src/HomeScreen/HomeScreen.jsx
@@ -1,4 +1,4 @@
-import "./HomeScreen.css";
+import "./HomeScreen.css"; // modified by AI agent
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { auth, db, googleProvider, functions } from "../firebase";
@@ -25,7 +25,6 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
   // 급식/학교 관련
   const [meals, setMeals] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [todayStr, setTodayStr] = useState("");
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [schoolName, setSchoolName] = useState(t("select_school"));
   const [eduCode, setEduCode] = useState("");
@@ -72,11 +71,6 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
       : `${yyyy}년 ${mm}월 ${dd}일 (${day})`;
   }
 
-  // 날짜 선택하면 UI에 반영
-  useEffect(() => {
-    setTodayStr(getDateDisplay(selectedDate));
-    // eslint-disable-next-line
-  }, [selectedDate, i18n.language]);
 
   // 로그인 감시
   useEffect(() => {
@@ -384,27 +378,7 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
 
       {/* 상단 header */}
       <div className="header">
-        <div className="date-row">
-          <div className="date-info">
-            <img className="calendar" src="calendar0.svg" alt="calendar icon" /> {/* Added alt text */}
-            {/* 달력 */}
-            <DatePicker
-              selected={selectedDate}
-              onChange={(date) => { setSelectedDate(date); setTodayStr(getDateDisplay(date)); }}
-              dateFormat={i18n.language === "en" ? "yyyy-MM-dd" : "yyyy년 MM월 dd일"}
-              customInput={
-                <span className="_2025-5-28" style={{ cursor: "pointer", fontWeight: 600 }}>
-                  {todayStr}
-                </span>
-              }
-              calendarClassName="meal-datepicker"
-              popperPlacement="bottom"
-              minDate={new Date(2020, 1, 1)}
-              maxDate={new Date(2099, 12, 31)}
-              showPopperArrow={false}
-              locale={i18n.language}
-            />
-          </div>
+        <div className="header-top">
           <div className="user-info">
             {user ? (
               <>
@@ -422,7 +396,7 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
         </div>
         <div className="school-info">
           <img className="school" src="school0.svg" alt="school icon" /> {/* Added alt text */}
-          <div className="div">{schoolName}</div>
+          <div className="school-name">{schoolName}</div>
         </div>
       </div>
 
@@ -431,8 +405,23 @@ export const HomeScreen = ({ onNavigate, className, ...props }) => {
         <div className="content">
           <div className="meal-title">
             <img className="utensils" src="utensils0.svg" alt="utensils icon" /> {/* Added alt text */}
-            <div className="div2">
-              {getDateDisplay(selectedDate)} {t("meal")}
+            <div className="div2 meal-date-row">
+              <span className="meal-date">{getDateDisplay(selectedDate)}</span>
+              <DatePicker
+                selected={selectedDate}
+                onChange={(date) => setSelectedDate(date)}
+                dateFormat={i18n.language === "en" ? "yyyy-MM-dd" : "yyyy년 MM월 dd일"}
+                customInput={
+                  <button className="date-select-btn">{t("change")}</button>
+                }
+                calendarClassName="meal-datepicker"
+                popperPlacement="bottom"
+                minDate={new Date(2020, 1, 1)}
+                maxDate={new Date(2099, 12, 31)}
+                showPopperArrow={false}
+                locale={i18n.language}
+              />
+              <span>{t("meal")}</span>
             </div>
           </div>
           <div className="meal-items">


### PR DESCRIPTION
## Summary
- remove duplicate top date display and show only login/logout in header
- align school icon with school name and style auth buttons
- allow date changes via picker next to meal date

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a16bcb9bf083309854865942342fa9