### PR TITLE
fix: force Vite to optimize deps to avoid 504 errors

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,9 @@ export default defineConfig({
   server: {
     host: '0.0.0.0'
   },
-  
+  optimizeDeps: {
+    // Force dependency pre-bundling to avoid Vite's
+    // "Outdated Optimize Dep" 504 errors during dev
+    force: true,
+  },
 })


### PR DESCRIPTION
## Summary
- force Vite to re-optimize dependencies on each dev start to avoid "Outdated Optimize Dep" 504 errors

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68aaa920674c8330b9df4edb3aa036b3