### PR TITLE
feat: highlight profile name input

### DIFF
--- a/src/Frame/Frame.css
+++ b/src/Frame/Frame.css
@@ -55,6 +55,25 @@
   margin: 0;
 }
 
+/* agent: highlight and expand name input */
+.name-row .name-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 2px solid #4d8cfb;
+  border-radius: 8px;
+  background: #eaf3ff;
+  font-size: 16px;
+}
+
+.name-row .save-btn {
+  display: inline-block;
+  width: auto;
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  margin-left: 8px;
+  margin-top: 0;
+}
+
 .edit-btn,
 .settings-btn {
   background: none;

--- a/src/Frame/Frame.jsx
+++ b/src/Frame/Frame.jsx
@@ -180,7 +180,11 @@ export const Frame = ({ className = "" }) => {
                   </>
                 ) : (
                   <>
-                    <input value={nameInput} onChange={(e) => setNameInput(e.target.value)} />
+                    <input
+                      className="name-input"
+                      value={nameInput}
+                      onChange={(e) => setNameInput(e.target.value)}
+                    />
                     <button className="save-btn" onClick={handleSave}>
                       {t("save")}
                     </button>


### PR DESCRIPTION
## Summary
- enlarge and highlight name input field on profile page
- adjust save button layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: vite Permission denied)

------
https://chatgpt.com/codex/tasks/task_e_68aab44619b08330b93527230b7925d4